### PR TITLE
fix: change rigging decorator agent to o3-mini

### DIFF
--- a/.hooks/generate_pr_description.py
+++ b/.hooks/generate_pr_description.py
@@ -66,7 +66,7 @@ def get_diff(base_ref: str, source_ref: str, *, exclude: list[str] | None = None
 def main(
     base_ref: str = "origin/main",
     source_ref: str = "HEAD",
-    generator_id: str = "groq/meta-llama/llama-4-scout-17b-16e-instruct",
+    generator_id: str = "o3-mini",
     max_diff_lines: int = 1000,
     exclude: list[str] | None = None,
 ) -> None:


### PR DESCRIPTION
# updates rigging PR decorator agent generator ID to `o3-mini`

**Key Changes:**

sensical changed based on recent change in model manifest https://community.openai.com/t/openai-dropped-price-of-o3/1284255

- [ ] updates rigging PR decorator agent generator ID to `o3-mini`

**Changed:**

- [ ] updates rigging PR decorator agent generator ID to `o3-mini`
---

## Generated Summary:

- Updated the default generator_id from "groq/meta-llama/llama-4-scout-17b-16e-instruct" to "o3-mini" in generate_pr_description.py.
- This change ensures that the PR description generation uses the new generator identifier by default.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
