### PR TITLE
docs: add airtbench dataset readme

### DIFF
--- a/dataset/README.md
+++ b/dataset/README.md
@@ -1,10 +1,31 @@
 # AIRTBench Dataset - External Release
 
+- [AIRTBench Dataset - External Release](#airtbench-dataset---external-release)
+  - [Overview](#overview)
+  - [Dataset Statistics](#dataset-statistics)
+  - [Model Success Rates](#model-success-rates)
+  - [Challenge Difficulty Distribution](#challenge-difficulty-distribution)
+  - [Data Dictionary](#data-dictionary)
+    - [Identifiers](#identifiers)
+    - [Primary Outcomes](#primary-outcomes)
+    - [Performance Metrics](#performance-metrics)
+    - [Resource Usage](#resource-usage)
+    - [Cost Analysis](#cost-analysis)
+    - [Conversation Content](#conversation-content)
+    - [Error Analysis](#error-analysis)
+  - [Usage Examples](#usage-examples)
+    - [Basic Analysis](#basic-analysis)
+    - [Cost Analysis](#cost-analysis-1)
+    - [Performance Analysis](#performance-analysis)
+    - [Conversation Content](#conversation-content-1)
+  - [Contact](#contact)
+  - [Version History](#version-history)
+
 ## Overview
 
-This dataset contains the complete experimental results from the AIRTBench paper: "AIRTBench: An AI Red Teaming Benchmark for Evaluating Language Models' Ability to Autonomously Discover and Exploit AI/ML Security Vulnerabilities."
+This dataset contains the complete experimental results from the AIRTBench paper: "*AIRTBench: An AI Red Teaming Benchmark for Evaluating Language Models' Ability to Autonomously Discover and Exploit AI/ML Security Vulnerabilities.*"
 
-The dataset includes 8,066 experimental runs across 12 different language models and 70 security challenges.
+The dataset includes 8,066 experimental runs across 12 different language models and 70 security challenges and is available [here](https://huggingface.co/datasets/dreadnode/AIRTBench/).
 
 ## Dataset Statistics
 


### PR DESCRIPTION
# external AIRTBench dataset `README` v1.0

**Key Changes:**

- [ ] adds external AIRTBench dataset `README` v1.0

**Added:**

- [ ] adds external AIRTBench dataset `README` v1.0
---

## Generated Summary:

- Updated the README to reflect the external release of the AIRTBench dataset.
- Added comprehensive sections including Overview, Dataset Statistics, and Model Success Rates.
- Introduced a detailed Data Dictionary outlining identifiers, primary outcomes, performance metrics, resource usage, cost analysis, conversation content, and error analysis.
- Provided multiple usage examples covering basic analysis, cost analysis, performance analysis, and conversation content extraction.
- Included version history and contact information for dataset support.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
