### PR TITLE
chore: pin deps in dockerfile for future version updates

### DIFF
--- a/airtbench/container/Dockerfile
+++ b/airtbench/container/Dockerfile
@@ -1,12 +1,20 @@
-FROM jupyter/scipy-notebook
+FROM jupyter/scipy-notebook@sha256:fca4bcc9cbd49d9a15e0e4df6c666adf17776c950da9fa94a4f0a045d5c4ad33
 
 RUN pip install \
-    torch \
-    torchvision \
-    torchaudio \
-    catboost \
-    GPy \
-    lightgbm \
-    xgboost \
-    kornia \
-    lief
+    adversarial-robustness-toolbox==1.19.1 \
+    catboost==1.2.8 \
+    eagerpy==0.30.0 \
+    foolbox==3.3.4 \
+    GPy==1.13.2 \
+    kornia==0.8.1 \
+    lief==0.16.5 \
+    lightgbm==4.6.0 \
+    numpy==1.24.3 \
+    plotly==6.0.1 \
+    requests==2.31.0 \
+    torch==2.7.0 \
+    torchaudio==2.7.0 \
+    torchvision==0.22.0 \
+    xgboost==3.0.0
+
+RUN pip install kornia_rs==0.1.9


### PR DESCRIPTION
# pin deps in custom Dockerfile for v1.0.0

**Key Changes:**

- [ ] closes #19 

**Changed:**

- [ ] pin deps in custom Dockerfile

with the working container from the current Dockerfile on `main`, i used `docker run --rm airtbench:latest pip freeze > current_dependencies.txt` to create a list of deps which i've then used to compile and propose in this PR

i also used inspect on `jupyter/scipy-notebook:latest` to get the digest, which is used in the Dockerfile

```bash
docker pull jupyter/scipy-notebook:latest
docker inspect jupyter/scipy-notebook:latest | grep -A 1 "RepoDigests"
```

tests:

```bash
uv run -m airtbench \                                                 
        --model together_ai/deepseek-ai/DeepSeek-R1 \
        --platform-api-key "$DREADNODE_TOKEN" \
        --token "$DREADNODE_TOKEN" \
        --server "$DREADNODE_SERVER_URL" \
        --challenges bear4 \
        --project airtbench-demo \
        --max-steps 100 \
        --enable-cache \
        --no-give-up
```

```bash
2025-06-20 06:40:35.380 | INFO     | airtbench.container:build_container:29 - Building container airtbench:latest from /Users/ads/git/AIRTBench-Code/airtbench/container/Dockerfile
Step 1/3 : FROM jupyter/scipy-notebook@sha256:fca4bcc9cbd49d9a15e0e4df6c666adf17776c950da9fa94a4f0a045d5c4ad33


---

## Generated Summary:

- Updated base image reference to use a specific sha256 digest for jupyter/scipy-notebook.
- Refactored pip installation commands to enforce specific package versions for torch, torchvision, torchaudio, and others.
- Added new dependencies: adversarial-robustness-toolbox, eagerpy, foolbox, plotly, requests.
- Introduced a separate pip install for kornia_rs with a fixed version.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)

Step 2/3 : RUN pip install     adversarial-robustness-toolbox==1.19.1     catboost==1.2.8     eagerpy==0.30.0     foolbox==3.3.4     GPy==1.13.2     kornia==0.8.1     lief==0.16.5     lightgbm==4.6.0     numpy==1.24.3     
plotly==6.0.1     requests==2.31.0     torch==2.7.0     torchaudio==2.7.0     torchvision==0.22.0     xgboost==3.0.0

---> Running in ab2514686458
Collecting adversarial-robustness-toolbox==1.19.1
Downloading adversarial_robustness_toolbox-1.19.1-py3-none-any.whl.metadata (11 kB)
Collecting catboost==1.2.8
Downloading catboost-1.2.8-cp311-cp311-manylinux2014_aarch64.whl.metadata (1.2 kB)
Collecting eagerpy==0.30.0
Downloading eagerpy-0.30.0-py3-none-any.whl.metadata (5.5 kB)
Collecting foolbox==3.3.4
Downloading foolbox-3.3.4-py3-none-any.whl.metadata (7.3 kB)
Collecting GPy==1.13.2
Downloading GPy-1.13.2.tar.gz (1.1 MB)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.1/1.1 MB 22.2 MB/s eta 0:00:00
...
---> 37fd20cb91ae
Successfully built 37fd20cb91ae
Successfully tagged airtbench:latest
2025-06-20 06:43:08.346 | INFO     | airtbench.container:build_container:44 - Container airtbench:latest built successfully
2025-06-20 06:43:08.396 | DEBUG    | airtbench.main:main:685 - Loaded 32 LLM challenges: ['bear4', 'brig1', 'brig2', 'canadianeh', 'extractor', 'extractor2', 'fragile', 'librarian', 'miner', 'mumble', 'pieceofcake', 'pirate_flag', 'popcorn', 'probe', 'probe2', 'puppeteer1', 'puppeteer2', 'puppeteer3', 'puppeteer4', 'spanglish', 'squeeze1', 'squeeze2', 'squeeze3', 'turtle', 'whatistheflag', 'whatistheflag2', 'whatistheflag3', 'whatistheflag4', 'whatistheflag5', 'whatistheflag6', 'whats_my_ip', 'whats_my_ip2']
```