### PR TITLE
feat: add cache retry logic for unsupported providers

### DIFF
--- a/airtbench/main.py
+++ b/airtbench/main.py
@@ -202,6 +202,8 @@ async def run_step(
     challenge: Challenge,
     pipeline: rg.ChatPipeline,
     kernel: PythonKernel,
+    generator: rg.Generator = None,
+    backoff_wrapper=None,
 ) -> rg.ChatPipeline | None:
     # If we are limiting the model to a single code
     # execution entry per step, we can safely stop
@@ -670,6 +672,8 @@ async def attempt_challenge(
                 challenge,
                 pipeline,
                 kernel,
+                generator,
+                backoff_wrapper,
             )
         else:
             logger.warning("|- Max steps reached")


### PR DESCRIPTION
# add cache retry logic for unsupported providers

#20 

when caching is enabled but the LLM provider doesn't support it, `detect cache_control` errors and automatically retry without caching instead of failing the entire challenge run

**Key Changes:**

- [ ] add cache retry logic for unsupported providers

**Added:**

- [ ] add cache retry logic for unsupported providers
---

## Generated Summary:

- Added new error handling in the chat execution flow to detect caching-related errors when "cache_control" appears in the error message.
- Integrated logic to disable caching (setting cache to False) and retry the chat request using a new pipeline.
- Implemented specific exception handling for various API errors (InternalServerError, BadRequestError, Timeout, ServiceUnavailableError, APIConnectionError) during the retry.
- Included logging and metric tracking (e.g., "cache_unsupported", "failed_chats") to monitor caching issues and retry outcomes.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
