### PR TITLE
chore: add dependency release age guardrails

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,7 @@
     ":automergeBranch",
   ],
   dependencyDashboardTitle: "Renovate Dashboard 🤖",
+  minimumReleaseAge: "3 days",
   suppressNotifications: ["prIgnoreNotification"],
   rebaseWhen: "conflicted",
   commitBodyTable: true,
@@ -19,7 +20,9 @@
     "github-actions",
     "dockerfile",
     "docker-compose",
-    "pre-commit"
+    "pre-commit",
+    "pep621",
+    "uv",
   ],
   ignorePaths: [],
   packageRules: [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,6 @@ ignore = [
 
 [tool.ruff.format]
 skip-magic-trailing-comma = false
+
+[tool.uv]
+exclude-newer = "3 days"


### PR DESCRIPTION
## Summary
- add a uv exclude-newer guardrail of 3 days
- add a Renovate minimum release age guardrail of 3 days
- enable Renovate managers for uv and pep621 project metadata

## Notes
- there were no open Renovate PRs to close after this change
---

## Generated Summary:

- Set a minimum release age of "3 days" in the Renovate configuration to delay merges.
- Add "pep621" and "uv" to the list of dependency managers in Renovate for extended support.
- Introduce a new [tool.uv] section in pyproject.toml with an "exclude-newer" setting to align with the release age.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
