### PR TITLE
fix: simplify Renovate manager config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,7 +22,6 @@
     "docker-compose",
     "pre-commit",
     "pep621",
-    "uv",
   ],
   ignorePaths: [],
   packageRules: [


### PR DESCRIPTION
Summary:
- remove the explicit uv manager from Renovate
- rely on pep621 for Python dependency updates

Testing:
- not run (Renovate config-only change)
---

## Generated Summary:

- Removed "uv" from the package list in renovate.json5 as it's no longer needed.
- Cleaned up configuration to focus on currently relevant package types.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
